### PR TITLE
Update icd path for nvidia.

### DIFF
--- a/wrapper
+++ b/wrapper
@@ -40,17 +40,19 @@ cp "$APPDIR"/usr/share/vulkan/icd.d/* "$ICD"
 
 # Patch driver path
 if [[ "$VENDOR" =~ intel ]]; then
-  export VK_ICD_FILENAMES="$ICD/intel_icd.i686.json:$ICD/intel_icd.x86_64.json"
-  sed -i "s|/usr|$APPDIR/usr|" "$ICD/intel_icd.i686.json"
-  sed -i "s|/usr|$APPDIR/usr|" "$ICD/intel_icd.x86_64.json"
+  VENDOR_NAME='intel'
 elif [[ "$VENDOR" =~ nvidia ]]; then
-  export VK_ICD_FILENAMES="$ICD/nvidia_icd.json"
-  sed -i "s|/usr|$APPDIR/usr|" "$ICD/nvidia_icd.json"
+  VENDOR_NAME='nvidia'
 elif [[ "$VENDOR" =~ radeon ]] || [[ "$VENDOR" =~ amd ]]; then
-  export VK_ICD_FILENAMES="$ICD/radeon_icd.i686.json:$ICD/radeon_icd.x86_64.json"
-  sed -i "s|/usr|$APPDIR/usr|" "$ICD/radeon_icd.i686.json"
-  sed -i "s|/usr|$APPDIR/usr|" "$ICD/radeon_icd.x86_64.json"
+  VENDOR_NAME='radeon'
 fi
+
+if [[ -n "$VENDOR_NAME" ]]; then
+  export VK_ICD_FILENAMES="$ICD/${VENDOR_NAME}_icd.i686.json:$ICD/${VENDOR_NAME}_icd.x86_64.json"
+  sed -i "s|/usr|$APPDIR/usr|" "$ICD/${VENDOR_NAME}_icd.i686.json"
+  sed -i "s|/usr|$APPDIR/usr|" "$ICD/${VENDOR_NAME}_icd.x86_64.json"
+fi
+
 
 # Log vulkan info
 if command -v vulkaninfo &>/dev/null; then


### PR DESCRIPTION
My current OS (rocky 9) has the following layout for icd.

Running on `NVIDIA 530.30.02` proprietary driver

```
$ tree icd.d
icd.d
├── intel_hasvk_icd.i686.json
├── intel_hasvk_icd.x86_64.json
├── intel_icd.i686.json
├── intel_icd.x86_64.json
├── lvp_icd.i686.json
├── lvp_icd.x86_64.json
├── nvidia_icd.i686.json
├── nvidia_icd.x86_64.json
├── radeon_icd.i686.json
└── radeon_icd.x86_64.json

0 directories, 10 files
```